### PR TITLE
Laravel 11 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,11 +32,11 @@
         "behat/behat": "^3.0",
         "behat/mink-browserkit-driver": "^2.1",
         "friends-of-behat/mink-extension": "^2.7",
-        "illuminate/contracts": "^8.0|^9.0|^10.0",
-        "illuminate/support": "^8.0|^9.0|^10.0",
-        "symfony/http-kernel": "^6.2",
+        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
+        "symfony/http-kernel": "^7.0",
         "symfony/event-dispatcher": "^6.2",
-        "phpunit/phpunit": "^9.5|^10.0"
+        "phpunit/phpunit": "^11.0"
     },
     "require-dev": {
         "marcocesarato/php-conventional-changelog": "^1.16"
@@ -49,5 +49,5 @@
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
-    "version": "1.0.4"
+    "version": "1.0.5"
 }


### PR DESCRIPTION
Update dependencies for Laravel 11 support

- symfony/http-kernel 6 to 7
- illuminate/contracts 10 to 11
- illuminate/support 10 to 11
- phpunit/phpunit 10 to 11