### PR TITLE
Require phpunit ^10 to prevent problems with PhpSpec ^7.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
         "symfony/http-kernel": "^7.0",
         "symfony/event-dispatcher": "^6.2",
-        "phpunit/phpunit": "^11.0"
+        "phpunit/phpunit": "^10.0"
     },
     "require-dev": {
         "marcocesarato/php-conventional-changelog": "^1.16"
@@ -49,5 +49,5 @@
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
-    "version": "1.0.5"
+    "version": "1.0.6"
 }


### PR DESCRIPTION
Downgrade PHPUnit requirement to ^10 due to compatibility issues with PhpSpec ^7.5 and Behat when installed concurrently